### PR TITLE
made update of sapcc and sapjvm version easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM centos:7
 
 ################################################################
+# DEFINE sapcc and jvm version
+################################################################
+ARG SAPCC_VERSION=2.12.5
+ARG SAPJVM_VERSION=8.1.067
+
+################################################################
 # General information
 ################################################################
-LABEL com.nabisoft.sapcc.version="2.12.4"
-LABEL com.nabisoft.sapcc.sapjvm.version="8.1.065"
+LABEL com.nabisoft.sapcc.version="2.12.5"
+LABEL com.nabisoft.sapcc.sapjvm.version="8.1.067"
+
 
 ################################################################
 # Upgrade + install dependencies
@@ -30,11 +37,11 @@ WORKDIR /tmp/sapdownloads
 # ATTENTION:
 # This automated download automatically accepts SAP's End User License Agreement (EULA).
 # Thus, when using this docker file as is you automatically accept SAP's EULA!
-RUN wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapcc-2.12.4-linux-x64.zip && \
-    wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapjvm-8.1.065-linux-x64.rpm && \
-    unzip sapcc-2.12.4-linux-x64.zip && \
-    rpm -i sapjvm-8.1.065-linux-x64.rpm && \
-	rpm -i com.sap.scc-ui-2.12.4-4.x86_64.rpm
+RUN wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapcc-$SAPCC_VERSION-linux-x64.zip && \
+    wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
+    unzip sapcc-$SAPCC_VERSION-linux-x64.zip && \
+    rpm -i sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
+	rpm -i com.sap.scc-ui-$SAPCC_VERSION-4.x86_64.rpm
 
 # You could also use Oracle JDK (feel free to skip JCE download + installation)
 #RUN wget --no-check-certificate --no-cookies --header "Cookie: gpw_e24=http%3a%2F%2Fwww.oracle.com%2Ftechnetwork%2Fjava%2Fjavase%2Fdownloads%2Fjdk8-downloads-2133151.html; oraclelicense=accept-securebackup-cookie;" -S "https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jdk-8u202-linux-x64.rpm" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ CMD /opt/sapjvm_8/bin/java \
   -Dosgi.embedded.cleanupOnSave=true \
   -Dosgi.usesLimit=30 \
   -Djava.awt.headless=true \
+  -Djdk.tls.server.protocols=TLSv1.2 \
   -Dio.netty.recycler.maxCapacity.default=256 \
   -jar plugins/org.eclipse.equinox.launcher_1.1.0.v20100507.jar
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,51 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
     cd sap-cloud-connector-docker
     ```
 
+1. Check current version of sapcc
+
+   - Goto [tools.hanaondemand.com](https://tools.hana.ondemand.com/#cloud) 
+
+   - Write down the current version of **Cloud Connector** (e.g. 2.12.5).
+
+   - Write down the current version of **SAP JVM** (e.g. 8.1.067)
+
+1. Update Dockerfile
+
+   Open the Dockerfile in this folder and replace the version numbers of the following lines with the numbers you wrote down. You find the lines right at the top of the file.
+
+   ```sh
+   ARG SAPCC_VERSION=2.12.5
+   ARG SAPJVM_VERSION=8.1.067
+   ```
+
+   Also update these lines with the new version numbers
+
+   ```
+   LABEL com.nabisoft.sapcc.version="2.12.5"
+   LABEL com.nabisoft.sapcc.sapjvm.version="8.1.067"
+   ```
+
+1. Instructions for the following commands
+
+   **In the following chapters replace the placeholder _\<sapcc-version\>_ with the sapcc version you wrote down.**
+
 1. Build the Docker image
 
     - Without Proxy
 
         ```sh
-        docker build -t sapcc:2.12.4 .
+        docker build -t sapcc:<sapcc-version> .
+        e.g.
+        docker build -t sapcc:2.12.5 .
         ```
+        **Hint:** don't forget the dot at the end of the line.
 
     - Behind a Proxy
 
         ```sh
-        docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:2.12.4 .
+        docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:<sapcc-version> .
+        e.g.
+        docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:2.12.5 .
         ```
 
         **Hint:** In a proxy environment your `docker build` command (see above) will fail in case you don't set the proxy as mentioned above or in case you use wrong proxy settings. Also consider that you might have to set the proxy manually for some software installed in the container, i.e. for the SAPCC you can set it manually for each SAPCP connection.
@@ -50,13 +83,17 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
     - Use this if you want to map the default SAP ports as they come on localhost (preferred)
 
         ```sh
-        docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:2.12.4
+        docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:<sapcc-version>
+        e.g.
+        docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:2.12.5
         ```
 
     - Use this one if "random" ports on localhost are fine for you
 
         ```sh
-        docker run -P -h mysapcc --name sapcc -d sapcc:2.12.4
+        docker run -P -h mysapcc --name sapcc -d sapcc:<sapcc-version>
+        e.g.
+        docker run -P -h mysapcc --name sapcc -d sapcc:2.12.5
         ```
 
 1. Starting/Stopping the container


### PR DESCRIPTION
Hi Nabi,
I introduced two ARG`s in the Dockerfile that are used within the file to pull the sapcc and sapjvm archives.
This way there is only one location that needs to be updated when new versions get released by SAP.

I also updated the README.md to reflect this change and tell the users to have a look at the versions before installation.

Happy new Year
Helmut