### PR TITLE
Updated SAP JVM and SAP CC Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:7
 ################################################################
 # DEFINE sapcc and jvm version
 ################################################################
-ARG SAPCC_VERSION=2.13.0
-ARG SAPJVM_VERSION=8.1.072
+ARG SAPCC_VERSION=2.13.1
+ARG SAPJVM_VERSION=8.1.075
 
 ################################################################
 # Upgrade + install dependencies


### PR DESCRIPTION
As the SAPCC 2.13.0 and JVM 8.1.072 aren't available anymore I updated the versions to build a working docker image. Please let me share that.