### PR TITLE
Replacing hardcoded value with variable SAPCC_RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=t
     wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
     unzip sapcc-$SAPCC_VERSION-linux-x64.zip && \
     rpm -i sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
-		rpm -i com.sap.scc-ui-$SAPCC_VERSION-8.x86_64.rpm
+    export SAPCC_RPM=$(ls com.sap.scc*.rpm) && \
+    rpm -i $SAPCC_RPM
 
 # set JAVA_HOME because this is needed by go.sh below, athers are calulated
 ENV JAVA_HOME=/opt/sapjvm_8/


### PR DESCRIPTION
The cloud connector install line is expecting an rpm file name that finishes in "-8.rpm" and the latest version is "-5.rpm". Instead of hard coding the value, we can search for the name of the sapcc rpm and use that.