### PR TITLE
make unpacking less sensitive (also bump patch ver)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 ################################################################
 # DEFINE sapcc and jvm version
 ################################################################
-ARG SAPCC_VERSION=2.13.1
+ARG SAPCC_VERSION=2.13.2
 ARG SAPJVM_VERSION=8.1.075
 
 ################################################################
@@ -35,7 +35,7 @@ RUN wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=t
     wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
     unzip sapcc-$SAPCC_VERSION-linux-x64.zip && \
     rpm -i sapjvm-$SAPJVM_VERSION-linux-x64.rpm && \
-		rpm -i com.sap.scc-ui-$SAPCC_VERSION-8.x86_64.rpm
+		rpm -i com.sap.scc-ui-${SAPCC_VERSION}*.x86_64.rpm
 
 # set JAVA_HOME because this is needed by go.sh below, athers are calulated
 ENV JAVA_HOME=/opt/sapjvm_8/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
 
    - Goto [tools.hanaondemand.com](https://tools.hana.ondemand.com/#cloud)
 
-   - Write down the current version of **Cloud Connector** (e.g. 2.13.1).
+   - Write down the current version of **Cloud Connector** (e.g. 2.13.2).
 
    - Write down the current version of **SAP JVM** (e.g. 8.1.067)
 
@@ -42,7 +42,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
    Open the Dockerfile in this folder and replace the version numbers of the following lines with the numbers you wrote down. You find the lines right at the top of the file.
 
    ```Dockerfile
-   ARG SAPCC_VERSION=2.13.1
+   ARG SAPCC_VERSION=2.13.2
    ARG SAPJVM_VERSION=8.1.067
    ```
 
@@ -57,7 +57,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
         ```sh
         #docker build -t sapcc:<sapcc-version> .
         #example:
-        docker build -t sapcc:2.13.1 .
+        docker build -t sapcc:2.13.2 .
         ```
 
         **Hint:** Don't forget the dot at the end of the line!
@@ -67,7 +67,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
         ```sh
         #docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:<sapcc-version> .
         #example:
-        docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:2.13.1 .
+        docker build --build-arg http_proxy=http://proxy.mycompany.corp:1234 --build-arg https_proxy=http://proxy.mycompany.corp:1234 -t sapcc:2.13.2 .
         ```
 
         **Hint:** In a proxy environment your `docker build` command (see above) will fail in case you don't set the proxy as mentioned above or in case you use wrong proxy settings. Also consider that you might have to set the proxy manually for some software installed in the container, i.e. for the SAPCC you can set it manually for each SAPCP connection.
@@ -90,7 +90,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
         ```sh
         #docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:<sapcc-version>
         #example:
-        docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:2.13.1
+        docker run -p 8443:8443 -h mysapcc --name sapcc -d sapcc:2.13.2
         ```
 
     - Use this one if "random" ports on localhost are fine for you
@@ -98,7 +98,7 @@ The Dockerfile is based on [https://github.com/PaxSchweiz/SAPHCPConnector/blob/m
         ```sh
         #docker run -P -h mysapcc --name sapcc -d sapcc:<sapcc-version>
         #example:
-        docker run -P -h mysapcc --name sapcc -d sapcc:2.13.1
+        docker run -P -h mysapcc --name sapcc -d sapcc:2.13.2
         ```
 
 1. Starting/Stopping the container


### PR DESCRIPTION
I noticed that with the latest patch version of the connector, 2.13.2, the unpacking / installation of the RPM package (with `rpm -i ...`) was failing due to some specific version number suffix `-5` at the end of the file, in the `Dockerfile` build instructions. This change makes that less sensitive, and just takes whatever is in the ZIP file, but still based on the major-minor-patch version specified.

I've also bumped up the reference to the latest patch version.