### PR TITLE
Fixes #17 externalize data storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ RUN chsh -s /bin/bash sccadmin
 EXPOSE 8443
 USER sccadmin
 WORKDIR /opt/sap/scc
+VOLUME /opt/sap/scc/config
+VOLUME /opt/sap/scc/scc_config
+VOLUME /opt/sap/scc/log
 
 # finally run sapcc as PID 1
 CMD ./go.sh


### PR DESCRIPTION
This will make the logs and configuration survive the container destruction and recreation.
Can be done without, but this should be the default behaviour in production.
Also, feels silly to use 3 volumes for this, but the only alternative I can think of is using symlinks
Marcello